### PR TITLE
UPdated the send to group Feature to receiver numbers

### DIFF
--- a/smsApi/settings.py
+++ b/smsApi/settings.py
@@ -43,20 +43,20 @@ ALLOWED_HOSTS = ['*']  ##allows all hosts
 
 #Devops suggested we include this for deployment
 SECRET_KEY= 'lmrffsgfhrilklg-za7#57vi!zr)ps8)2anyona25###dl)s-#s=7=vn_'
-# TWILIO_ACCOUNT_SID = 'AC24dc3ff423be936f3efd0503045fd4e8'
-# TWILIO_AUTH_TOKEN = '70846d53642b6fc91abb485b88a0fa96'
-# TWILIO_NUMBER = '+13026637959'
-# TELESIGN_API = 'mp6UoFnveiSDjHSQmNdNxLrpNca844of69XAWOHYu+xRZsadpUm5XsQ50utSNAzOl/tj3lOxQMIwlmaHXL2cxQ=='
-# TELESIGN_CUST = '163CFEDD-EB4D-4DEE-949C-9F44F6292FA5'
+# TWILIO_ACCOUNT_SID = ''
+# TWILIO_AUTH_TOKEN = ''
+# TWILIO_NUMBER = ''
+# TELESIGN_API = ''
+# TELESIGN_CUST = ''
 # #MessageBird
-# MB_ACCESS_KEY = 'T9KCkelsJGqAwRU6Htdy2LI7m'
+# MB_ACCESS_KEY = ''
 # #Gatewayapi.com
-# GA_KEY='OCALazyE4I9G26K7fXiMcdyn'
-# GA_SECRET='F-ltreMai8m-M2QMtWsVoTNF&4RU4XmAUjC^4l*d'
+# GA_KEY=''
+# GA_SECRET=''
 # #D7
-# D7_TOKEN= 'dmF5aTIxODA6VjRjNUZmRm4='
-# D7_USERNAME= 'vayi2180'
-# D7_PASSWORD= 'V4c5FfFn'
+# D7_TOKEN= ''
+# D7_USERNAME= ''
+# D7_PASSWORD= ''
 
 #add twillio sid , authentication token and your twilio number
 # TWILIO_ACCOUNT_SID = os.getenv("TWILIO_ACCOUNT_SID") # obtained from twilio.com/console 

--- a/smsApp/models.py
+++ b/smsApp/models.py
@@ -96,7 +96,7 @@ class Message(models.Model):
         choices=MESSAGE_CHOICES,
         default=DRAFT,
     )
-    dateScheduled = models.DateTimeField(null=True)
+    dateScheduled = models.DateTimeField(default=timezone.now, null=True)
     
     LANG_CHOICES = (
 
@@ -227,7 +227,7 @@ class Message(models.Model):
 class SenderDetails(models.Model):
     senderID = models.ForeignKey(Sender, related_name='details', on_delete=models.CASCADE)
     default = models.BooleanField(default=False)
-    sid = models.CharField(max_length=1200)
+    sid = models.CharField(max_length=1200, blank=True, null=True)
     token = models.CharField(max_length=1300)
     verified_no = models.CharField(max_length=20000, blank=False)
     SERVICE_CHOICES = [

--- a/smsApp/serializers.py
+++ b/smsApp/serializers.py
@@ -1,6 +1,7 @@
 from rest_framework import serializers
 from .models import Recipient, Message, Group, GroupNumbers, SenderDetails, Sender
 import uuid
+from django.utils import timezone
 
 
 
@@ -25,7 +26,7 @@ class MessageSerializer(serializers.ModelSerializer):
     ]
     service_type = serializers.ChoiceField(choices=Message.SERVICE_CHOICES, read_only=True)
     grouptoken = serializers.CharField(read_only=True)
-    # dateScheduled = serializers.DateField(input_formats="%Y-%m-%dT%H:%M:%S.%fZ")
+    dateScheduled = serializers.DateTimeField(default=timezone.now())
     date_created = serializers.CharField(read_only=True)
     messageStatus = serializers.ChoiceField(choices=['D', 'S','F','R','P','U','SC'], read_only=True)
     language = serializers.ChoiceField(choices=Message.LANG_CHOICES, default='en', required=False)
@@ -43,10 +44,12 @@ class GroupSerializer(serializers.ModelSerializer):
     groupName = serializers.CharField(required=True)
     groupID = serializers.UUIDField(format='hex_verbose', initial=uuid.uuid4, read_only=True)
     numbers = serializers.StringRelatedField(many=True, read_only=True)
+    senderID = serializers.SlugRelatedField(slug_field='senderID', queryset=Sender.objects.all())
     class Meta:
         model = Group
-        fields = ["groupName", "groupID", "dateCreated", "numbers"]
+        fields = "__all__"
         depth = 1
+        # fields = ["groupName", "groupID", "dateCreated", "numbers", "senderID"]
 
 class GroupNumbersSerializer(serializers.ModelSerializer):
     dateCreated = serializers.DateTimeField(read_only=True)
@@ -74,7 +77,7 @@ class SenderSerializer(serializers.ModelSerializer):
 
 class SenderDetailsSerializer(serializers.ModelSerializer):
     sender = serializers.CharField(source="senderID.senderID", required=True)
-    sid = serializers.CharField(max_length=1200, required=True)
+    sid = serializers.CharField(max_length=1200, required=False)
     token = serializers.CharField(max_length=1200, required=True)
     SERVICE_CHOICES = [
         ("INFOBIP", 'IF'),
@@ -100,6 +103,6 @@ class SenderDetailsSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = SenderDetails
-        fields = ("sid", "token", "service_name", "sender")
+        fields = ("sid", "token", "service_name", "sender", "verified_no")
 
     

--- a/smsApp/urls.py
+++ b/smsApp/urls.py
@@ -106,16 +106,16 @@ urlpatterns = [
    # path('v1/sms/message/translate', translateMessages),
 
    #Group Views
-   path("v1/sms/list_group", GroupList.as_view(), name="list-group"),
-   path("v1/sms/list_group/<senderID>", GroupBySenderList.as_view(), name="list-group"),
-   path("v1/sms/create_group", GroupCreate.as_view(), name="update-group"),
-   path("v1/sms/group_update/<str:pk>", GroupDetail.as_view(), name="update-group"),
-   path("v1/sms/group_delete/<str:groupname>", GroupDelete.as_view(), name="delete-group"),
-   path("v1/sms/group_recipient/", GroupNumbersList.as_view(), name="group-numbers"),
-   path("v1/sms/group_recipient/create", GroupNumbersCreate.as_view(), name="create-group-numbers"),
-   path("v1/sms/group_recipient_list/<str:senderID>", GroupNumbersBySenderList.as_view(), name="list-group-numbers-senderID"),
-   path("v1/sms/group_recipient_update/<str:pk>", update_group_number, name="update-group-umbers"),
-   path("v1/sms/group_recipient_delete/<str:pk>", GroupNumbersDetail.as_view(), name="update-group-umbers"),
+   # path("v1/sms/list_group", GroupList.as_view(), name="list-group"),
+   # path("v1/sms/list_group/<senderID>", GroupBySenderList.as_view(), name="list-group"),
+   # path("v1/sms/create_group", GroupCreate.as_view(), name="update-group"),
+   # path("v1/sms/group_update/<str:pk>", GroupDetail.as_view(), name="update-group"),
+   # path("v1/sms/group_delete/<str:groupname>", GroupDelete.as_view(), name="delete-group"),
+   # path("v1/sms/group_recipient/", GroupNumbersList.as_view(), name="group-numbers"),
+   # path("v1/sms/group_recipient/create", GroupNumbersCreate.as_view(), name="create-group-numbers"),
+   # path("v1/sms/group_recipient_list/<str:groupname>", GroupNumbersBySenderList.as_view(), name="list-group-numbers-senderID"),
+   # path("v1/sms/group_recipient_update/<str:pk>", update_group_number, name="update-group-umbers"),
+   # path("v1/sms/group_recipient_delete/<str:pk>", GroupNumbersDetail.as_view(), name="update-group-umbers"),
    
 ]
 

--- a/smsApp/views.py
+++ b/smsApp/views.py
@@ -86,7 +86,7 @@ class SendSingMsgCreate(generics.CreateAPIView):
         token = service.token
         service_type = service.service_name
         verified_no = service.verified_no
-        print(service, service_type, token, sid)
+        print(service, service_type, token, sid, verified_no)
         receiver = request.data.get("receiver")
         content = request.data.get("content")
         language = request.data.get("language")
@@ -102,26 +102,27 @@ class SendSingMsgCreate(generics.CreateAPIView):
 
 
                 serializer_message = MessageSerializer(data=message_dict)
-
-
-                client = Client(sid,token)
+                
+                client = Client(f"{sid}",
+                                f"{token}")
                 if serializer_message.is_valid():
+                    print('yeah')
+                    value = serializer_message.save()
+                    value.service_type = 'TW'
                     try:
-                        value = serializer_message.save()
-                        value.service_type = 'TW'
                         if (language != 'en' or language != None or language != " " ):
                             original_txt.append(content)
                             content = translateMsg(content, language)
                             value.language = language
                             
                             message = client.messages.create(
-                                from_=verified_no,
+                                from_=senderID,
                                 to=receiver,
                                 body=content
                             )
                         else:
                             message = client.messages.create(
-                                from_=verified_no,
+                                from_=senderID,
                                 to=receiver,
                                 body=content
                             )
@@ -177,7 +178,7 @@ class SendSingMsgCreate(generics.CreateAPIView):
                                 'statusCode': '400',
                                 'details': 'The Phone Number is Not registered to Twilio'
                             }
-                        }, status=status.HTTP_400_BAD_REQUEST)      
+                        }, status=status.HTTP_400_BAD_REQUEST)                             
                 return Response({
                     "success": "False",
                     "status": "F",
@@ -193,7 +194,7 @@ class SendSingMsgCreate(generics.CreateAPIView):
                 }, status=status.HTTP_400_BAD_REQUEST)
 
             #Infobip
-            elif (service_type == 'IF'):
+            elif (service_type.upper() == 'IF' or service_type.upper() == "INFOBIP"):
                 logger.error("posting to message in INFOBIP")
 
                 message_dict = {'senderID':senderID, 'receiver':receiver, 'content':content}
@@ -251,6 +252,9 @@ class SendSingMsgCreate(generics.CreateAPIView):
                             value.messageStatus = "E"
                         if ( data["messages"][0]["status"]["groupId"] == 5):
                             value.messageStatus = "FR"
+                    else:
+                        value.messageStatus = "F"
+                        return Response("someting went wrong while sending, please try again")
                     value.save()
                     # print(data)
                     if len(original_txt) != 0:
@@ -260,7 +264,7 @@ class SendSingMsgCreate(generics.CreateAPIView):
                     return Response({"message": "Not Valid"})
             
             #For Telesign
-            elif (service_type == 'TS'):
+            elif (service_type == 'TS' or service_type.upper() == "TELESIGN"):
                 logger.error("posting to message in telesign")
                 message_dict = {'senderID':senderID, 'receiver':receiver, 'content':content}
                 serializer_message = MessageSerializer(data=message_dict)
@@ -337,7 +341,7 @@ class SendSingMsgCreate(generics.CreateAPIView):
                     return Response({"success":"False","message": "Invalid credentials","messageID":f"{value.messageID}","data": "Not Valid", "service type": f"{service_type}"}, status=status.HTTP_400_BAD_REQUEST)
             
             #for MessageBird
-            elif (service_type == 'MB'):
+            elif (service_type == 'MB' or service_type.upper() == "MESSAGEBIRD"):
 
                 logger.error("posting to message in MessageBird")
                 message_dict = {'senderID':senderID, 'receiver':receiver, 'content':content}
@@ -360,13 +364,9 @@ class SendSingMsgCreate(generics.CreateAPIView):
                             body=content
                         )
                         # data = json.loads(message)
-                        print(client)
-                        print(message.__dict__)
+
                         data = message.__dict__
                         item = data['_recipients']['items'][0].__dict__
-                        print(item['recipient'])
-                        print(data)
-                        print(data['id'])
                         if data['gateway'] == 10:
                             value.messageStatus = "F"
                             return Response({
@@ -423,7 +423,7 @@ class SendSingMsgCreate(generics.CreateAPIView):
                     return Response({"success":"False","message": "Invalid credentials","messageID":"","data": "Not Valid", "service type": f"{service_type}"}, status=status.HTTP_400_BAD_REQUEST)
             
             #For GatewayAPi
-            elif (service_type == 'GA'):
+            elif (service_type == 'GA' or service_type.upper() == "GATEWAYAPI"):
                 logger.error("posting to message in GatewayAPi")
                 message_dict = {'senderID':senderID, 'receiver':receiver, 'content':content}
                 serializer_message = MessageSerializer(data=message_dict)
@@ -482,7 +482,7 @@ class SendSingMsgCreate(generics.CreateAPIView):
             else:
                 return Response({"success":"False","message": "","messageID":"","data": "N/A", f"service_type {service_type}": "Not Supported"}, status=status.HTTP_400_BAD_REQUEST)
         else:
-            return Response({f"{receiver} should be a number starting with +,1,0 ": "Not Supported"}, status=status.HTTP_400_BAD_REQUEST)
+            return Response({f"{receiver}  does not start with +,1,0 or is a single number.": "Not Supported"}, status=status.HTTP_400_BAD_REQUEST)
 
 
 
@@ -903,21 +903,27 @@ class GroupCreate(generics.CreateAPIView):
     def post(self, request, *args, **kwargs):
         groupName = request.data.get("groupName")
         senderID = request.data.get("senderID")
-        queryset = Group.objects.filter(senderID=senderID, groupName=groupName)
+        try:
+            get_object_or_404(Sender, senderID=senderID)
+            queryset = Group.objects.filter(senderID=senderID, groupName=groupName)
 
-        if senderID == "string" or senderID == None:
-            return Response({"Failure": status.HTTP_400_BAD_REQUEST, "Message": "String is empty", "Data": {"userID": "string is empty"}})
-        if groupName == "string" or groupName == None:
-            return Response({"Failure": status.HTTP_400_BAD_REQUEST, "Message": "String is empty", "Data": {"groupName": "empty"}})
-        if queryset.exists():
-            return Response({"This group exists and it has same user, please specify another group with or change the senderID"}, status=status.HTTP_400_BAD_REQUEST)
-        else:
-            # self.create(request, *args, **kwargs)
-            serializer = GroupSerializer(data=request.data)
-            if serializer.is_valid():
-                value = serializer.save()
-                groupID = value.groupID
-            return Response({"Success": "True", "status": status.HTTP_201_CREATED, "Message": "Group Created", "Data": request.data, "groupID": groupID})
+            if senderID == "string" or senderID == None:
+                return Response({"Failure": status.HTTP_400_BAD_REQUEST, "Message": "String is empty", "Data": {"userID": "string is empty"}})
+            if groupName == "string" or groupName == None:
+                return Response({"Failure": status.HTTP_400_BAD_REQUEST, "Message": "String is empty", "Data": {"groupName": "empty"}})
+            if queryset.exists():
+                return Response({"This group exists and it has same user, please specify another group with or change the senderID"}, status=status.HTTP_400_BAD_REQUEST)
+            else:
+                # self.create(request, *args, **kwargs)
+                serializer = GroupSerializer(data=request.data)
+                if serializer.is_valid():
+                    value = serializer.save()
+                    groupID = value.groupID
+                    value.save()
+                    return Response({"Success": "True", "status": status.HTTP_201_CREATED, "Message": "Group Created", "Data": request.data, "groupID": groupID})
+                return Response({"Failure": status.HTTP_400_BAD_REQUEST, "Message": "Bad Request", "Data": serializer.errors})
+        except:
+            return Response({"Failure": status.HTTP_400_BAD_REQUEST, "Message": "Bad Request", "Data": serializer.errors})
 
 # This is the function for updating and deleting each recipient in a list
 
@@ -978,12 +984,13 @@ class GroupNumbersBySenderList(APIView):
     The user can List all numbers in a specific group. This requires  {"userID":""}
     """
 
-    def get(self, request, senderID, format=None):
+    def get(self, request, groupname, format=None):
         if ValueError:
             return Response({"Success": False, "Message": "Failed Request", "Data": "String UserID needed", 'status': status.HTTP_400_BAD_REQUEST})
-        groupNumber = GroupNumbers.objects.filter(group__userID=senderID)
+        # groupNumber = GroupNumbers.objects.filter(group__groupName=groupname)
+        groupNumber = get_object_or_404(GroupNumbers, group__groupName=groupname)
         serializer = GroupNumbersSerializer(groupNumber, many=True)
-        return Response({"Success": "True", "status": status.HTTP_200_OK, "Message": f"PhoneNumbers Available to {senderID}", "Numbers": serializer.data})
+        return Response({"Success": "True", "status": status.HTTP_200_OK, "Message": f"PhoneNumbers Available to {groupname}", "Numbers": serializer.data})
 
 
 class GroupNumbersCreate(generics.CreateAPIView):
@@ -1584,32 +1591,49 @@ class SendGroupSms(views.APIView):
         Send SMS to multiple recipients. 
         {
         "groupID": "autogenerated from v1/sms/create_group",
-        "content": "",
-        "senderID": "your user id",
+        "conttextent": "",
+        "senderID": "senderID",
         "language": "can be null"
         }
     """
     def post(self, request):
+        #request senderID from user
         senderID = request.data.get("senderID")
         sender = get_object_or_404(Sender, senderID=senderID)
-        # sender = Sender.objects.get(senderID=senderID)
-        # sender.details.get(default=2)
-        service = sender.details.get(default=True)
-        sid = service.sid
-        token = service.token
-        service_type = service.service_name
-        verified_no = service.verified_no
-        print(service, service_type, token, sid)
+        print(sender)
+        #collecting the info of user from the sender table which is linked to sender details table
+        account = sender.details.get(default=True)
+        sid = account.sid
+        token = account.token
+        service_type = account.service_name
+        verified_no = account.verified_no
+        
+        #Original Text before translation occurs
         original_txt = []
+        #log error
         logger.error("posting to group message")
-
-
-        original_txt = []
+        
+        #messageStatus to return
         msgstatus = []
-        groupID = request.data["groupID"]
+
+        #more request data from user
         text = request.data["content"]
         language = request.data["language"]
-        numbers = get_numbers_from_group(request, groupID)
+        receiver = request.data["receiver"]
+
+        #Handling the multiple entry info for user to send to group
+        receiver = receiver.split(',')
+        numbers = []
+        for number in receiver:
+            number.strip()
+            numbers.append(number) 
+        numbers = list(set(numbers))
+        #check if it only one number
+        if len(numbers) <=1:
+            result = {'You need to add more numbers...this is a group feature'}
+            msgstatus.append(result)
+            return Rsponse(msgstatus)
+
         logger.error("Infobib")
         grouptoken = uuid.uuid4()
         #INFOBIP
@@ -1664,9 +1688,12 @@ class SendGroupSms(views.APIView):
                         result = {"success":"True","status": value.messageStatus, "message": f"{value.content}", "messageID":f"{value.messageID}","groupToken":f"{value.grouptoken}", "data": {"to": To, "msg-id":IF_MSID, "description":description}}
                         msgstatus.append(result)
                         print(msgstatus, number)
+                    else:
+                        result = {"someting went wrong while sending to this {}, please try again".format(number)}
+                        msgstatus.append(result)
                     value.save()
                 else:
-                    result = {"success":"False","message": f"something went wrong while sending to {number}","status":status.HTTP_400_BAD_REQUEST}
+                    result = {"success":"False","message": f"Please check that this {number} is valid as we cant send to it","status":status.HTTP_400_BAD_REQUEST}
                     msgstatus.append(result)
                     # return Response({
                     #     "Success":"False","Message": f"something went wrong while sending to {number}","status":status.HTTP_400_BAD_REQUEST})
@@ -1773,7 +1800,7 @@ class SendGroupSms(views.APIView):
             return Response(msgstatus)
 
         # #MessageBird
-        elif (service_type == 'MB'):
+        elif (service_type.upper() == 'MB' or service_type.upper() == 'MESSAGEBIRD'):
             for number in numbers:
                 msg_dict = {'grouptoken':grouptoken, 'content':text, 'senderID':senderID, 'receiver':number}
                 serializer = MessageSerializer(data=msg_dict)
@@ -1870,7 +1897,7 @@ class SendGroupSms(views.APIView):
             return Response(msgstatus)
         
         #GatewayApi
-        elif (service_type == 'GA'):
+        elif (service_type.upper() == 'GA' or service_type.upper() == 'GATEWAYAPI'):
             for number in numbers:
                 msg_dict = {'grouptoken':grouptoken, 'content':text, 'senderID':senderID, 'receiver':number}
                 serializer = MessageSerializer(data=msg_dict)


### PR DESCRIPTION
The send to group/bulk sms no longer requires user to input groupID or create group. 

Users can just add more numbers separated by comma and then send.

The create group is now deprecated.